### PR TITLE
ENG-167 percona-release postinst script requires gpg2

### DIFF
--- a/deb/debian/control
+++ b/deb/debian/control
@@ -11,5 +11,5 @@ Vcs-Git: https://github.com/percona/percona-repositories.git
 Package: percona-release
 Architecture: all
 Pre-Depends: gpgv
-Depends: lsb-release, ${misc:Depends}
+Depends: lsb-release, gnupg2, ${misc:Depends}
 Description: Package to install Percona gpg key and APT repos


### PR DESCRIPTION
Add dependency(gpg2) required for postinst script. 