### PR TITLE
PREL-14 remove gnupg calls

### DIFF
--- a/deb/debian/control
+++ b/deb/debian/control
@@ -10,6 +10,5 @@ Vcs-Git: https://github.com/percona/percona-repositories.git
 
 Package: percona-release
 Architecture: all
-Pre-Depends: gpgv
-Depends: lsb-release, gnupg2, ${misc:Depends}
+Depends: lsb-release, ${misc:Depends}
 Description: Package to install Percona gpg key and APT repos

--- a/deb/debian/postinst
+++ b/deb/debian/postinst
@@ -27,7 +27,6 @@ set -e
 
 case "$1" in
     configure)
-      eval "/usr/bin/apt-key add /etc/apt/trusted.gpg.d/percona-keyring.gpg  ${SUPRESSOR}"
       /usr/bin/percona-release enable original
       if [[ -f  ${OLDREPOFILE} ]]; then
         mv -f ${OLDREPOFILE} ${OLDREPOFILE}.bak

--- a/scripts/percona-release-tests.sh
+++ b/scripts/percona-release-tests.sh
@@ -113,6 +113,7 @@ for _alias in ${ALIASES}; do
   [[ ${_alias} = ppg11.6 ]] && REPOS=${PPG11_6_REPOS:-}
   [[ ${_alias} = pdmdb4.2.2 ]] && REPOS=${PDMDB_4_2_2_REPOS:-}
   [[ ${_alias} = pdmdb4.2 ]] && REPOS=${PDMDB_4_2_REPOS:-}
+  [[ ${_alias} = ppg12 ]] && REPOS=${PPG12_REPOS:-}
   [[ ${_alias} = ppg12.1 ]] && REPOS=${PPG12_1_REPOS:-}
   [[ -z ${REPOS} ]] && REPOS="original tools"
     ./${SCRIPT} setup ${_alias}

--- a/scripts/percona-release.sh
+++ b/scripts/percona-release.sh
@@ -9,9 +9,9 @@ if [[ $(id -u) -gt 0 ]]; then
   exit 1
 fi
 #
-ALIASES="ps56 ps57 ps80 psmdb34 psmdb36 psmdb40 psmdb42 pxb80 pxc56 pxc57 pxc80 ppg11 ppg11.5 ppg11.6 ppg12.1 pdmdb4.2 pdmdb4.2.2"
+ALIASES="ps56 ps57 ps80 psmdb34 psmdb36 psmdb40 psmdb42 pxb80 pxc56 pxc57 pxc80 ppg11 ppg11.5 ppg11.6 ppg12 ppg12.1 pdmdb4.2 pdmdb4.2.2"
 COMMANDS="enable enable-only setup disable"
-REPOSITORIES="original ps-80 pxc-80 psmdb-40 psmdb-42 tools ppg-11 ppg-11.5 ppg-11.6 ppg-12.1 pdmdb-4.2 pdmdb-4.2.2"
+REPOSITORIES="original ps-80 pxc-80 psmdb-40 psmdb-42 tools ppg-11 ppg-11.5 ppg-11.6 ppg-12 ppg-12.1 pdmdb-4.2 pdmdb-4.2.2"
 COMPONENTS="release testing experimental"
 URL="http://repo.percona.com"
 
@@ -29,6 +29,7 @@ PPG11_5_DESC="Percona Distribution for PostgreSQL 11.5"
 PPG11_6_DESC="Percona Distribution for PostgreSQL 11.6"
 PDMDB4_2_DESC="Percona Distribution for MongoDB 4.2"
 PDMDB4_2_2_DESC="Percona Distribution for MongoDB 4.2.2"
+PPG12_DESC="Percona Distribution for PostgreSQL 12"
 PPG12_1_DESC="Percona Distribution for PostgreSQL 12.1"
 #
 PS80REPOS="ps-80 tools"
@@ -41,6 +42,7 @@ PPG11_5_REPOS="ppg-11.5 tools"
 PPG11_6_REPOS="ppg-11.6 tools"
 PDMDB4_2_2_REPOS="pdmdb-4.2.2"
 PDMDB4_2_REPOS="pdmdb-4.2"
+PPG12_REPOS="ppg-12 tools"
 PPG12_1_REPOS="ppg-12.1 tools"
 #
 AUTOUPDATE=NO
@@ -212,6 +214,7 @@ function enable_repository {
   [[ ${1} = "ppg-11.6" ]]    && DESCRIPTION=${PPG11_6_DESC}
   [[ ${1} = "pdmdb-4.2" ]]    && DESCRIPTION=${PDMDB4_2_DESC}
   [[ ${1} = "pdmdb-4.2.2" ]]    && DESCRIPTION=${PDMDB4_2_2_DESC}
+  [[ ${1} = "ppg-12" ]]    && DESCRIPTION=${PPG12_DESC}
   [[ ${1} = "ppg-12.1" ]]    && DESCRIPTION=${PPG12_1_DESC}
   [[ -z ${DESCRIPTION} ]] && DESCRIPTION=${DEFAULT_REPO_DESC}
   echo "* Enabling the ${DESCRIPTION} repository"
@@ -237,7 +240,7 @@ function disable_dnf_module {
   REPO_NAME=${1}
   MODULE="mysql"
   PRODUCT="Percona-Server"
-  if [[ ${REPO_NAME} = "ppg11" ]] || [[ ${REPO_NAME} = "ppg11.5" ]] || [[ ${REPO_NAME} = "ppg11.6" ]] || [[ ${REPO_NAME} = "ppg12.1" ]]; then
+  if [[ ${REPO_NAME} = "ppg11" ]] || [[ ${REPO_NAME} = "ppg11.5" ]] || [[ ${REPO_NAME} = "ppg11.6" ]] || [[ ${REPO_NAME} = "ppg12" ]] || [[ ${REPO_NAME} = "ppg12.1" ]]; then
     MODULE="postgresql"
     PRODUCT="Percona PostgreSQL Distribution"
   fi
@@ -277,9 +280,10 @@ function enable_alias {
   [[ ${1} = ppg11.6 ]] && REPOS=${PPG11_6_REPOS:-}
   [[ ${1} = pdmdb4.2 ]] && REPOS=${PDMDB4_2_REPOS:-}
   [[ ${1} = pdmdb4.2.2 ]] && REPOS=${PDMDB4_2_2_REPOS:-}
+  [[ ${1} = ppg12 ]] && REPOS=${PPG12_REPOS:-}
   [[ ${1} = ppg12.1 ]] && REPOS=${PPG12_1_REPOS:-}
   [[ -z ${REPOS} ]] && REPOS="original tools"
-  if [[ ${1} = ps80 ]] || [[ ${1} = pxc80 ]] || [[ ${1} = ppg11 ]] || [[ ${1} = ppg11.5 ]] || [[ ${1} = ppg11.6 ]] || [[ ${1} = ppg12.1 ]]; then
+  if [[ ${1} = ps80 ]] || [[ ${1} = pxc80 ]] || [[ ${1} = ppg11 ]] || [[ ${1} = ppg11.5 ]] || [[ ${1} = ppg11.6 ]] || [[ ${1} = ppg12 ]] || [[ ${1} = ppg12.1 ]]; then
     disable_dnf_module ${1}
   fi
   for _repo in ${REPOS}; do

--- a/scripts/percona-release.sh
+++ b/scripts/percona-release.sh
@@ -66,7 +66,8 @@ function check_specified_alias {
   local found=NO
   [[ -z ${1} ]] && echo "ERROR: No product alias specified!" && show_help && exit 2
   for _alias in ${ALIASES}; do
-    [[ ${_alias} = ${1} ]] && found=YES
+    NAME=$(echo ${1} | sed 's/-//' )
+    [[ ${_alias} = ${NAME} ]] && found=YES
   done
   if [[ ${found} = NO ]]; then
     echo "ERROR: Unknown alias specification: ${1}"


### PR DESCRIPTION
We need gnupg while calling apt-key command. Adding gpg to /etc/apt/trusted.gpg.d/ doesn't require apt-key call.

```
root@97e736308169:/# apt update
Hit:1 http://deb.debian.org/debian buster InRelease
Hit:2 http://security.debian.org/debian-security buster/updates InRelease 
Hit:3 http://deb.debian.org/debian buster-updates InRelease               
Get:4 http://repo.percona.com/ps-80/apt buster InRelease [15.7 kB]        
Err:4 http://repo.percona.com/ps-80/apt buster InRelease
  The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 9334A25F8507EFA5
Reading package lists... Done
W: GPG error: http://repo.percona.com/ps-80/apt buster InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 9334A25F8507EFA5
E: The repository 'http://repo.percona.com/ps-80/apt buster InRelease' is not signed.
N: Updating from such a repository can't be done securely, and is therefore disabled by default.
N: See apt-secure(8) manpage for repository creation and user configuration details.
root@97e736308169:/# cp ./percona-keyring.gpg /etc/apt/trusted.gpg.d/
root@97e736308169:/# apt update
Hit:1 http://deb.debian.org/debian buster InRelease
Hit:2 http://security.debian.org/debian-security buster/updates InRelease
Get:3 http://repo.percona.com/ps-80/apt buster InRelease [15.7 kB]  
Hit:4 http://deb.debian.org/debian buster-updates InRelease         
Get:5 http://repo.percona.com/ps-80/apt buster/main Sources [1674 B]
Get:6 http://repo.percona.com/ps-80/apt buster/main amd64 Packages [18.0 kB]
Fetched 19.7 kB in 1s (33.6 kB/s)  
Reading package lists... Done
Building dependency tree       
Reading state information... Done
9 packages can be upgraded. Run 'apt list --upgradable' to see them.
```