### PR TITLE
Enable overrides via /etc/default/percona-release

### DIFF
--- a/deb/debian/postinst
+++ b/deb/debian/postinst
@@ -33,6 +33,19 @@ case "$1" in
         mv -f ${OLDREPOFILE} ${OLDREPOFILE}.bak
       fi
 
+      mkdir -p /etc/default
+      cat << EOF > /etc/default/percona-release
+## The following variables accept overrides for percona-release
+#
+#INTERACTIVE=YES
+#ALIASES="ps56 ps57 ps80 psmdb34 psmdb36 psmdb40 psmdb42 pxb80 pxc56 pxc57 pxc80 ppg11 ppg11.5 ppg11.6 ppg11.7 ppg12 ppg12.2 pdmdb4.2 pdmdb4.2.2 pdmysql8.0.18 pdmysql8.0"
+#COMMANDS="enable enable-only setup disable"
+#REPOSITORIES="original ps-80 pxc-80 psmdb-40 psmdb-42 tools ppg-11 ppg-11.5 ppg-11.6 ppg-11.7 ppg-12 ppg-12.2 pdmdb-4.2 pdmdb-4.2.2 pdmysql-8.0 pdmysql-8.0.18"
+#COMPONENTS="release testing experimental"
+#URL="http://repo.percona.com"
+#
+EOF
+
 cat << EOF
 The percona-release package now contains a percona-release script that can enable additional repositories for our newer products.
 

--- a/rpm/percona-release.template
+++ b/rpm/percona-release.template
@@ -63,6 +63,19 @@ For more information, please visit:
 
 EOF
 
+mkdir -p /etc/default
+cat << EOF > /etc/default/percona-release
+## The following variables accept overrides for percona-release
+#
+#INTERACTIVE=YES
+#ALIASES="ps56 ps57 ps80 psmdb34 psmdb36 psmdb40 psmdb42 pxb80 pxc56 pxc57 pxc80 ppg11 ppg11.5 ppg11.6 ppg11.7 ppg12 ppg12.2 pdmdb4.2 pdmdb4.2.2 pdmysql8.0.18 pdmysql8.0"
+#COMMANDS="enable enable-only setup disable"
+#REPOSITORIES="original ps-80 pxc-80 psmdb-40 psmdb-42 tools ppg-11 ppg-11.5 ppg-11.6 ppg-11.7 ppg-12 ppg-12.2 pdmdb-4.2 pdmdb-4.2.2 pdmysql-8.0 pdmysql-8.0.18"
+#COMPONENTS="release testing experimental"
+#URL="http://repo.percona.com"
+#
+EOF
+
 %preun
 #
 if [ $1 -eq 0 ]; then

--- a/scripts/percona-release-tests.sh
+++ b/scripts/percona-release-tests.sh
@@ -64,6 +64,29 @@ function expect_repofile_deleted {
   [[ -f ${LOCATION}/${REPO}-${COMPONENT}.${EXT} ]] && echo "* ERROR! Repo file for ${REPO}-${COMPONENT} has not been disabled!" && exit 1
   [[ ! -f ${LOCATION}/${REPO}-${COMPONENT}.${EXT}.bak ]] && echo "* ERROR! Repo backup file for ${REPO}-${COMPONENT} has not been created!" && exit 1
 }
+
+function test_default_overrides {
+    local -i file_exists=0
+    local -r repo_url='https://repo.percona.com/test/'
+    local -r repo_name="percona-original-release"
+    local -r repo_file="${LOCATION}/${repo_name}.${EXT}"
+
+    if [[ -f /etc/default/percona-release ]]; then
+        file_exists=1
+        mv -v /etc/default/percona-release /etc/default/percona-release.backupfortest
+        printf 'URL="%s"\n' "${repo_url}" > /etc/default/percona-release
+    fi
+
+    ./${SCRIPT} enable-only original release
+    if [[ "${file_exists}" -eq 1 ]]; then
+        mv -v /etc/default/percona-release.backupfortest /etc/default/percona-release
+    fi
+
+    grep -Fq "${repo_url}" "${repo_file}" || {
+        echo "* ERROR! Repo file for  ${repo_name} does not contain the override setting"
+        exit 1
+    }
+}
 ####
 ###
 ##
@@ -100,6 +123,15 @@ done
 #
 ./${SCRIPT} disable all all
 rm -fv ${LOCATION}/*.bak
+## Test for overrides
+if [[ ! -d /etc/default ]]; then
+    echo "WARNING: /etc/default does not exist"
+else
+    test_default_overrides
+fi
+./${SCRIPT} disable all all
+rm -fv ${LOCATION}/*.bak
+## End
 #
 for _alias in ${ALIASES}; do
   REPOS=""
@@ -124,3 +156,4 @@ for _alias in ${ALIASES}; do
       expect_repofile_created ${_repository} release
     done
 done
+

--- a/scripts/percona-release.sh
+++ b/scripts/percona-release.sh
@@ -15,6 +15,10 @@ REPOSITORIES="original ps-80 pxc-80 psmdb-40 psmdb-42 tools ppg-11 ppg-11.5 ppg-
 COMPONENTS="release testing experimental"
 URL="http://repo.percona.com"
 
+if [[ -f /etc/default/percona-release ]]; then
+    . /etc/default/percona-release
+fi
+
 #
 DESCRIPTION=""
 DEFAULT_REPO_DESC="Percona Original"


### PR DESCRIPTION
Adding initial support for limited overrides of:
- `INTERACTIVE`
- `ALIASES`
- `COMMANDS`
- `REPOSITORIES`
- `COMPONENTS`
- `URL`

This allows the user to do the following:
- Use an internal mirror with the tool
- Avoid interactive requests without editing the script
- Optionally hide some of the options provided in output (e.g. hide
  MongoDB repositories on a MySQL instance)