### PR TITLE
PREL-151 Behaviour between APT and YUM differs

### DIFF
--- a/scripts/percona-release.sh
+++ b/scripts/percona-release.sh
@@ -341,12 +341,14 @@ case $1 in
   enable )
     shift
     enable_repository $@
+    run_update
     ;;
   enable-only )
     shift
     echo "* Disabling all Percona Repositories"
     disable_repository all all
     enable_repository $@
+    run_update
     ;;
   setup )
     shift


### PR DESCRIPTION
Whilst yum will automatically update its cache when you enable a
repo, apt does not and thus different tasks are required when
automating its use, or even manual use.  Adding run_update as a
task after enabling repos would resolve this.

* Added `run_update` to `enable` and `enable-only` commands as a
  post-task to ensure that Debian and Red Hat derivatives behave
  in the same way for the user
* Set `AUTOUPDATE` during distro detection in tests
* Added `test_auto_update` to check that updates occur when
  `AUTOUPDATE` is set during tests
* Add extra information when reporting additional repos being enabled
  during tests, showing the count and an `ls`
* Relocated tests for overrides