### PR TITLE
PREL-214 The original release repo is forced to be enabled

### DIFF
--- a/deb/debian/postinst
+++ b/deb/debian/postinst
@@ -28,7 +28,15 @@ set -e
 case "$1" in
     configure)
       eval "/usr/bin/apt-key add /etc/apt/trusted.gpg.d/percona-keyring.gpg  ${SUPRESSOR}"
-      /usr/bin/percona-release enable original release || true
+      if [ -f /etc/default/percona-release ]; then
+          . /etc/default/percona-release
+      fi
+      if [ "${REPOSITORIES}" == "" ]; then
+          REPOSITORIES="original prel"
+      fi
+      if echo "${REPOSITORIES} | grep -Fq original"; then
+          /usr/bin/percona-release enable original release || true
+      fi
       /usr/bin/percona-release enable prel release || true
       if [[ -f  ${OLDREPOFILE} ]]; then
         mv -f ${OLDREPOFILE} ${OLDREPOFILE}.bak

--- a/rpm/percona-release.template
+++ b/rpm/percona-release.template
@@ -48,7 +48,15 @@ if [ "x${OS}" = "x7" ]; then
     rpm --import %{_sysconfdir}/pki/rpm-gpg/RPM-GPG-KEY-Percona
 fi
 #
-%{_bindir}/percona-release enable original release
+if [ -f /etc/default/percona-release ]; then
+    . /etc/default/percona-release
+fi
+if [ "${REPOSITORIES}" == "" ]; then
+    REPOSITORIES="original prel"
+fi
+if echo "${REPOSITORIES} | grep -Fq original"; then
+    %{_bindir}/percona-release enable original release
+fi
 %{_bindir}/percona-release enable prel release
 #
 cat << EOF


### PR DESCRIPTION
When there is an override for `REPOSITORIES` in
`/etc/default/percona-release`, it is ignored when it comes to the installation of the `percona-release` package and the original repository is forced to be enabled, even if it should not be.

* Updated `deb/debian/postinst` and `rpm/percona-release.template` to check for a non-empty `REPOSITORIES` override and only enable the original repository when appropriate