### PR TITLE
Fix wrong name of Percona Server for MySQL 8.0

### DIFF
--- a/deb/debian/postinst
+++ b/deb/debian/postinst
@@ -43,7 +43,7 @@ case "$1" in
 cat << EOF
 The percona-release package now contains a percona-release script that can enable additional repositories for our newer products.
 
-For example, to enable the Percona Server 8.0 repository use:
+For example, to enable the Percona Server for MySQL 8.0 repository use:
 
   percona-release setup ps80
 

--- a/rpm/percona-release.template
+++ b/rpm/percona-release.template
@@ -54,7 +54,7 @@ fi
 cat << EOF
 The percona-release package now contains a percona-release script that can enable additional repositories for our newer products.
 
-For example, to enable the Percona Server 8.0 repository use:
+For example, to enable the Percona Server for MySQL 8.0 repository use:
 
   percona-release setup ps80
 


### PR DESCRIPTION
"_Percona Server 8.0_" is confusing.
_ps80_ is "_Percona Server for MySQL 8.0_"

This PR fixes two occurrences. 

Thanks,